### PR TITLE
CERBERUS: Added header, updated artplanner name, updated elevation mapping repo

### DIFF
--- a/1-Software.md
+++ b/1-Software.md
@@ -70,6 +70,8 @@ Created by: CTU-CRAS-NORLAB
 
 Tags: `mobility 🦵`, `autonomy 🧠`, `perception 📷`, `networking 📶`, `simulation 🖥️`
 
+## Team CERBERUS
+
 ### [Graph-based Exploration Planner 2.0](https://github.com/ntnu-arl/gbplanner_ros)
 
 Exploration path planning by Team CERBERUS.
@@ -82,7 +84,7 @@ Exploration path planning by Team CERBERUS.
 
 Tags: `mobility 🦵`, `autonomy 🧠`
 
-### [ANYmal Local Planner](https://github.com/leggedrobotics/art_planner)
+### [ANYmal Rough Terrain Planner](https://github.com/leggedrobotics/art_planner)
 
 Sampling based path planning for ANYmal based on 2.5D height maps, by Team CERBERUS.
 
@@ -94,9 +96,9 @@ Research-oriented visual-inertial mapping framework, written in C++, for creatin
 
 Tags: `perception 📷`
 
-### [Elevation Mapping](https://github.com/leggedrobotics/elevation_mapping)
+### [Elevation Mapping](https://github.com/leggedrobotics/elevation_mapping_cupy)
 
-Robot-centric elevation mapping for rough terrain navigation by Team CERBERUS.
+Robot-centric elevation mapping on GPU for rough terrain navigation and locomotion by Team CERBERUS.
 
 Tags: `perception 📷`, `mobility 🦵`
 

--- a/4-Publications.md
+++ b/4-Publications.md
@@ -62,6 +62,8 @@ Pavel Petracek, Vit Kratky, Matej Petrlik, Tomas Baca, Radim Kratochvil and Mart
 
 1. P. Fankhauser, M. Bloesch, C. Gehring, M. Hutter, M. and R. Siegwart, “Robot-centric elevation mapping with uncertainty estimates,” In Mobile Service Robotics (pp. 433-440). 
 
+1. T. Miki, L. Wellhausen, R. Grandia, F. Jenelten, T. Homberger, and M. Hutter, "Elevation mapping for locomotion and navigation using gpu", Submitted to 2022 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS).
+
 ### Perception: Multi-Robot Mapping
 
 1. T. Schneider, M. Dymczyk, M. Fehr, K. Egger, S. Lynen, I. Gilitschenski, and R. Siegwart. "maplab: An open framework for research in visual-inertial mapping and localization," IEEE Robotics and Automation Letters 3, no. 3 (2018): 1418-1425.
@@ -80,11 +82,13 @@ Pavel Petracek, Vit Kratky, Matej Petrlik, Tomas Baca, Radim Kratochvil and Mart
 
 1. L. Schmid, V. Reijgwart, L. Ott, J. Nieto, R. Siegwart, and C. Cadena. "A Unified Approach for Autonomous Volumetric Exploration of Large Scale Environments under Severe Odometry Drift," IEEE Robotics and Automation Letters 6, no. 3 (2021): 4504-4511
 
-### Path Planning: Local Planning
+### Path Planning: Legged Robot Navigation Planning
 
 1. L. Wellhausen, and M. Hutter, “Rough Terrain Navigation for Legged Robots using Reachability Planning and Template Learning,” 2021 IEEE/RSJ International Conference on intelligent robots and systems (IROS 2021), September 27-October 1, 2021, Prague, Czech Republic, Open-Source Git Repo: https://github.com/leggedrobotics/art_planner
 
 1. B. Yang, L. Wellhausen, T. Miki, M. Liu, M. Hutter -“Real-time Optimal Navigation Planning Using Learned Motion Costs”, IEEE International Conference on Robotics and Automation (ICRA), May 30-June 5, 2021, Xi'an, China
+
+1. L. Wellhausen, and M. Hutter, "Artplanner: Robust legged robot navigation in the field", Submitted to Field Robotics.
 
 ### Systems Papers
 


### PR DESCRIPTION
- Updated the name of the ANYmal local planner repo.
- Updated the elevation mapping repo to our latest one, used during the Finals
- Added a `Team CERBERUS` header before our software list. I'd suggest doing this for every team to add some structure. The list will be very long once all team's repos are merged.
- Added latest publications for ANYmal planning and elevation mapping